### PR TITLE
update aws region name format to be consistent with AWS

### DIFF
--- a/src/targets/createUserPool.ts
+++ b/src/targets/createUserPool.ts
@@ -9,7 +9,7 @@ import { USER_POOL_AWS_DEFAULTS } from "../services/cognitoService";
 import { userPoolToResponseObject } from "./responses";
 import { Target } from "./Target";
 
-const REGION = "local";
+const REGION = "pc-local-1";
 const ACCOUNT_ID = "local";
 
 const generator = shortUUID(


### PR DESCRIPTION
aws-jwt-verify expects the region name to be in a specific format. This change allows cognito local to work with it.